### PR TITLE
Agregar segunda impresora central de apuntes

### DIFF
--- a/print/printexam.php
+++ b/print/printexam.php
@@ -132,6 +132,11 @@ if ($form->get_data ()) {
 		$target = "10.110.2.244";
 	}
 	
+	// TODO This is outrageous!
+	if ($printer == "Edificio-A-CentralDeApuntes2") {
+		$target = "10.50.2.210";
+	}
+	
 	// codigo extra borrar
 	$cmd_result = shell_exec ( "ping -c 1 -w 1 " . $target );
 	$result = explode ( ",", $cmd_result );

--- a/settings.php
+++ b/settings.php
@@ -202,20 +202,21 @@ $settings->add(new admin_setting_configcheckbox('emarking_enablemanageprinters',
 		.get_string('viewpermitsprinters', 'mod_emarking', $CFG->wwwroot."/mod/emarking/print/usersprinters.php"),
 		0, PARAM_BOOL));
 
+/*
 // The remote printer's name
 $settings->add(new admin_setting_configtext('emarking_printername',
 		get_string('printername', 'mod_emarking'),
 		get_string('printername_help', 'mod_emarking'),
 		'', PARAM_TAGLIST));
+*/
 
-/*
 //PRINT RANDOM
 // Enable printing random
 $settings->add(new admin_setting_configcheckbox('emarking_enableprintingrandom',
 		get_string('enableprintingrandom', 'mod_emarking'),
 		get_string('enableprintingrandom_help', 'mod_emarking'),
 		0, PARAM_BOOL));	
-*/
+
 //PRINT LIST
 // Enable printing the list of students
 $settings->add(new admin_setting_configcheckbox('emarking_enableprintinglist',

--- a/settings.php
+++ b/settings.php
@@ -208,14 +208,14 @@ $settings->add(new admin_setting_configtext('emarking_printername',
 		get_string('printername_help', 'mod_emarking'),
 		'', PARAM_TAGLIST));
 
-
+/*
 //PRINT RANDOM
 // Enable printing random
 $settings->add(new admin_setting_configcheckbox('emarking_enableprintingrandom',
 		get_string('enableprintingrandom', 'mod_emarking'),
 		get_string('enableprintingrandom_help', 'mod_emarking'),
 		0, PARAM_BOOL));	
-
+*/
 //PRINT LIST
 // Enable printing the list of students
 $settings->add(new admin_setting_configcheckbox('emarking_enableprintinglist',

--- a/settings.php
+++ b/settings.php
@@ -202,13 +202,13 @@ $settings->add(new admin_setting_configcheckbox('emarking_enablemanageprinters',
 		.get_string('viewpermitsprinters', 'mod_emarking', $CFG->wwwroot."/mod/emarking/print/usersprinters.php"),
 		0, PARAM_BOOL));
 
-/*
+
 // The remote printer's name
 $settings->add(new admin_setting_configtext('emarking_printername',
 		get_string('printername', 'mod_emarking'),
 		get_string('printername_help', 'mod_emarking'),
 		'', PARAM_TAGLIST));
-*/
+
 
 //PRINT RANDOM
 // Enable printing random

--- a/settings.php
+++ b/settings.php
@@ -201,13 +201,13 @@ $settings->add(new admin_setting_configcheckbox('emarking_enablemanageprinters',
 		get_string('viewadminprints', 'mod_emarking', $CFG->wwwroot."/mod/emarking/print/printers.php")
 		.get_string('viewpermitsprinters', 'mod_emarking', $CFG->wwwroot."/mod/emarking/print/usersprinters.php"),
 		0, PARAM_BOOL));
-/*
+
 // The remote printer's name
 $settings->add(new admin_setting_configtext('emarking_printername',
 		get_string('printername', 'mod_emarking'),
 		get_string('printername_help', 'mod_emarking'),
 		'', PARAM_TAGLIST));
-*/
+
 
 //PRINT RANDOM
 // Enable printing random


### PR DESCRIPTION
Arreglo de problema en settings.php, por líneas comentadas que no debían estarlo aún, ya que no se ha completado el desarrollo actual de los mantenedores de impresoras.

Me comuniqué con el jefe de desarrollo para verificar mis cambios y validarlos, es necesario el cambio por la urgencia de una segunda impresora en central de apuntes. Todo esto en base a la solicitud de Guido Rojas.