### PR TITLE
Se resuelven varios issues

### DIFF
--- a/forms/predefined_comments_form.php
+++ b/forms/predefined_comments_form.php
@@ -75,7 +75,7 @@ class emarking_predefined_comments_form extends moodleform
         
         // Validate columns, minimum number and first two to be userid and attemptid
         if (count($reader->get_columns()) < 0) {
-            $errors['comments'] = 'At least one column is required';
+        	$errors['comments'] = get_string('onecolumnrequired', 'mod_emarking');
         }
         
         $reader->init();
@@ -85,7 +85,7 @@ class emarking_predefined_comments_form extends moodleform
         }
         
         if($current < 1) {
-            $errors['comments'] = 'At least one line is required';
+        	$errors['comments'] = get_string('twolinesrequired', 'mod_emarking');
         }
         
         return $errors;

--- a/lang/en/emarking.php
+++ b/lang/en/emarking.php
@@ -86,6 +86,7 @@ $string['markerscanseenothing'] = 'Pages are assigned to criteria but no markers
 $string['markerscanseepageswithcriteria'] = 'Markers can see only those pages assigned to the criteria they can mark.';
 $string['assignedmarkers'] = 'Assigned markers';
 $string['currentstatus'] = 'Current status';
+$string['noneditingteacherconfiguration'] = 'As a Non-editing teacher you can not change de settings.';
 
 // GENERAL
 $string['criteria'] = 'Criteria';
@@ -176,6 +177,8 @@ $string['addpredefinedcomments'] = 'Import predefined comments from Excel';
 $string['predefinedcomments'] = 'Predefined comments';
 $string['predefinedcomments_help'] = 'Paste a column from Excel (with or without a header) to import all the rows as predefined comments.';
 $string['onlyfirstcolumn'] = 'Only the first column will be imported. A sample of the data is shown below:';
+$string['onecolumnrequired'] = 'At least one column is required';
+$string['twolinesrequired'] = 'At least two lines are required';
 
 $string['mobilephoneregex'] = 'Mobile phone regex';
 $string['mobilephoneregex_help'] = 'A regular expression to validate a correct mobile phone';

--- a/lang/es/emarking.php
+++ b/lang/es/emarking.php
@@ -92,6 +92,7 @@ $string['markerscanseenothing'] = 'Hay páginas asignadas a criterios, pero no c
 $string['markerscanseepageswithcriteria'] = 'Correctores ven solo las páginas de los criterios que tienen asignados.';
 $string['assignedmarkers'] = 'Correctores asignados';
 $string['currentstatus'] = 'Configuración actual';
+$string['noneditingteacherconfiguration'] = 'Como ayudante no puedes modificar la configuración.';
 
 // GENERAL
 $string['criteria'] = 'Criterios';
@@ -181,6 +182,8 @@ $string['addpredefinedcomments'] = 'Importar comentarios desde Excel';
 $string['predefinedcomments'] = 'Comentarios predefinidos';
 $string['predefinedcomments_help'] = 'Pegue una columna de comentarios desde Excel (con o sin encabezado), cada fila se creará como un comentario predefinido.';
 $string['onlyfirstcolumn'] = 'Solo la primera columna es importada. Un ejemplo de los datos a importar se muestra abajo:';
+$string['twolinesrequired'] = 'Debes ingresar dos o mas líneas';
+$string['onecolumnrequired'] = 'Debes ingresar una o mas columnas';
 
 $string['mobilephoneregex'] = 'Expresión regular de celulares';
 $string['mobilephoneregex_help'] = 'Una expresión regular que valide un número de teléfono celular en su país. (p.ej: +569\d{8})';

--- a/marking/regrades.php
+++ b/marking/regrades.php
@@ -265,6 +265,7 @@ $query = "select
 		rg.accepted AS rgaccepted,
 		rg.motive,
 		rg.comment,
+		dr.status as draftstatus,
 		comment.bonus,
         ol.score as originalscore,
         rg.bonus as originalbonus,
@@ -365,7 +366,11 @@ foreach ($questions as $question) {
     $row[] = $question->description;
     $row[] = $question->rgaccepted ? $originalinfo : $currentinfo;
     $row[] = $statusicon;
-    $row[] = $question->rgaccepted ? $currentinfo : '';
+    if($question->rgaccepted && $question->draftstatus == EMARKING_STATUS_PUBLISHED){
+    	$row[] = $question->rgaccepted ? $currentinfo : '';
+    }else{
+    	$row[] = " ";
+    }
     $row[] = $linktext;
     
     $data[] = $row;

--- a/marking/settings.php
+++ b/marking/settings.php
@@ -71,8 +71,8 @@ if (! has_capability ( 'mod/emarking:supervisegrading', $context )) {
 			'objectid' => $cm->id,
 	);
 	// Add to Moodle log so some auditing can be done
-	\mod_emarking\event\markers_assigned::create ( $item )->trigger ();
-	print_error ( get_string('invalidaccess','mod_emarking' ) );
+	//\mod_emarking\event\markers_assigned::create ( $item )->trigger ();
+	print_error ( get_string('noneditingteacherconfiguration','mod_emarking' ) );
 }
 
 echo $OUTPUT->header();


### PR DESCRIPTION
WC-1483, se corrigió una forma del error. Que no muestre el puntaje de la recolección hasta que el profesor publique nuevamente la prueba. Falta, desde la vista del profesor, arreglar que si no modifica el puntaje no cuenta como publicada. Esto fue reportado por QA recientemente.
WC-1547, WC-1545, WC-1546: Error langs, comentarios predefinidos. Y validación del formulario.
WC-1542: Se comenta linea 74 de marking/settings.php que generaba un error, \mod_emarking\event\markers_assigned::create ( $item )->trigger ();. Se agrega un nuevo lang para el error del ayudante.